### PR TITLE
Splice fix

### DIFF
--- a/mutalyzer/GenRecord.py
+++ b/mutalyzer/GenRecord.py
@@ -845,6 +845,7 @@ class GenRecord() :
                 self.__output.addMessage(__file__, 2, warning,
                     "Mutation on splice site in gene %s %s." % (
                     gene.name, str_transcript))
+                transcript.translate = False
             elif intronPos <= config.get('spliceWarn'):
                 self.__output.addMessage(__file__, 2, warning,
                     "Mutation near splice site in gene %s %s." % (


### PR DESCRIPTION
Migrated from [GitLab !19](https://git.lumc.nl/mutalyzer/mutalyzer/merge_requests/19)

Proposed fix for [Trac #164](https://humgenprojects.lumc.nl/trac/mutalyzer/ticket/164).

This fix prevents the translation when a splice alarm is triggered.