### PR TITLE
Fix service location in SOAP WSDL document

### DIFF
--- a/doc/config.rst
+++ b/doc/config.rst
@@ -185,10 +185,10 @@ REVERSE_PROXIED
 .. _config-soap-wsdl-url:
 
 SOAP_WSDL_URL
-  URL to the SOAP webservice WSDL document. Used for linking to it from the
-  documentation page on the website.
+  URL to the SOAP webservice WSDL document. Used to build the WSDL document
+  and for linking to it from the documentation page on the website.
 
-  `Default value:` ``https://mutalyzer.nl/services/?wsdl``
+  `Default value:` `None`
 
 .. _config-json-root-url:
 
@@ -196,7 +196,7 @@ JSON_ROOT_URL
   URL to the HTTP/RPC+JSON webservice root (without trailing slash). Used for
   linking to it from the documentation page on the website.
 
-  `Default value:` ``https://mutalyzer.nl/json``
+  `Default value:` `None`
 
 
 Piwik settings

--- a/mutalyzer/config/default_settings.py
+++ b/mutalyzer/config/default_settings.py
@@ -72,8 +72,8 @@ PROTEIN_LINK_EXPIRATION = 60 * 60 * 24 * 30
 # seconds).
 NEGATIVE_PROTEIN_LINK_EXPIRATION = 60 * 60 * 24 * 5
 
-# URL to the SOAP webservice WSDL document. Used for linking to it from the
-# documentation page on the website.
+# URL to the SOAP webservice WSDL document. Used to build the WSDL document
+# and for linking to it from the documentation page on the website.
 SOAP_WSDL_URL = 'https://mutalyzer.nl/services/?wsdl'
 
 # URL to the HTTP/RPC+JSON webservice root (without trailing slash). Used for

--- a/mutalyzer/entrypoints/service_soap.py
+++ b/mutalyzer/entrypoints/service_soap.py
@@ -40,6 +40,22 @@ logging.getLogger('spyne.protocol.xml').setLevel(log_level)
 
 #: WSGI application instance.
 application = WsgiApplication(soap.application)
+
+# By default, the first request will trigger a build of the WSDL document,
+# using the context (service location) from that request. For example, if the
+# first request is on `http://localhost/` and subsequent requests are on
+# `https://mutalyzer.nl/services/`, they will not have a valid WSDL document.
+#
+# This is actually what we do on our production infrastructure, where the
+# service is tested (on localhost) after it has been started.
+#
+# The fix is to force a build of the WSDL document and specifying the location
+# to use.
+#
+# http://spyne.io/docs/2.10/reference/server.html#spyne.server.wsgi.WsgiApplication
+if settings.SOAP_WSDL_URL:
+    application.doc.wsdl11.build_interface_document(settings.SOAP_WSDL_URL)
+
 if settings.REVERSE_PROXIED:
     application = _ReverseProxied(application)
 

--- a/mutalyzer/website/views.py
+++ b/mutalyzer/website/views.py
@@ -50,8 +50,8 @@ def global_context():
         'release'             : mutalyzer.__version_info__[-1] != 'dev',
         'copyright_years'     : mutalyzer.COPYRIGHT_YEARS,
         'contact_email'       : settings.EMAIL,
-        'soap_wsdl_url'       : settings.SOAP_WSDL_URL,
-        'json_root_url'       : settings.JSON_ROOT_URL,
+        'soap_wsdl_url'       : settings.SOAP_WSDL_URL or 'https://mutalyzer.nl/services/?wsdl',
+        'json_root_url'       : settings.JSON_ROOT_URL or 'https://mutalyzer.nl/json',
         'piwik'               : settings.PIWIK,
         'piwik_base_url'      : settings.PIWIK_BASE_URL,
         'piwik_site_id'       : settings.PIWIK_SITE_ID,
@@ -144,7 +144,8 @@ def soap_api():
            .documentation { white-space: pre-line; }
     """
     soap_server = HttpBase(soap.application)
-    soap_server.doc.wsdl11.build_interface_document(settings.SOAP_WSDL_URL)
+    soap_server.doc.wsdl11.build_interface_document(
+        settings.SOAP_WSDL_URL or 'https://mutalyzer.nl/services/?wsdl')
     wsdl_string = soap_server.doc.wsdl11.get_interface_document()
 
     xsl_file = os.path.join(


### PR DESCRIPTION
By default, the first request to the SOAP service will trigger a
build of the WSDL document, using the context (service location)
from that request. For example, if the first request is on
`http://localhost/` and subsequent requests are on
`https://mutalyzer.nl/services/`, they will not have a valid WSDL
document.

This is actually what we do on our production infrastructure,
where the service is tested (on localhost) after it has been
started.

The fix is to force a build of the WSDL document and specifying
the location to use.

http://spyne.io/docs/2.10/reference/server.html#spyne.server.wsgi.WsgiApplication