### PR TITLE
Using the Werkzeug reloader is configurable

### DIFF
--- a/doc/config.rst
+++ b/doc/config.rst
@@ -246,3 +246,13 @@ NEGATIVE_PROTEIN_LINK_EXPIRATION
   (in seconds).
 
   `Default value:` `60 * 60 * 24 * 5` (5 days)
+
+USE_RELOADER
+  Enable the `Werkzeug reloader
+  <http://werkzeug.pocoo.org/docs/0.10/serving/#reloader>`_ for the website.
+
+  This is disabled by default due to `a bug with using the reloader
+  <https://github.com/mitsuhiko/werkzeug/issues/461#issuecomment-139369694>`_
+  in combination with ``python -m mutalyzer.entrypoints.website``.
+
+  `Default value:` `False`

--- a/mutalyzer/config/default_settings.py
+++ b/mutalyzer/config/default_settings.py
@@ -88,3 +88,9 @@ PIWIK_BASE_URL = 'https://piwik.example.com'
 
 # Piwik site ID for Mutalyzer.
 PIWIK_SITE_ID = 1
+
+# Enable the Werkzeug reloader for the website.
+# This is disabled by default due to a bug with using the reloader in
+# combination with `python -m mutalyzer.entrypoints.website`.
+# https://github.com/mitsuhiko/werkzeug/issues/461#issuecomment-139369694
+USE_RELOADER = False

--- a/mutalyzer/entrypoints/website.py
+++ b/mutalyzer/entrypoints/website.py
@@ -59,7 +59,8 @@ def debugserver(host, port):
     """
     Run the website with the Python built-in HTTP server.
     """
-    application.run(host=host, port=port, debug=True, use_reloader=True)
+    application.run(host=host, port=port, debug=True,
+                    use_reloader=settings.USE_RELOADER)
 
 
 def main():


### PR DESCRIPTION
The Werkzeug reloader is disabled by default due to a bug with
using it in combination with `python -m mutalyzer.entrypoints.website`.

https://github.com/mitsuhiko/werkzeug/issues/461#issuecomment-139369694