### PR TITLE
Create legend only after gene model enrichment

### DIFF
--- a/mutalyzer/variantchecker.py
+++ b/mutalyzer/variantchecker.py
@@ -1773,23 +1773,6 @@ def check_variant(description, output):
     record = GenRecord.GenRecord(output)
     record.record = retrieved_record
 
-    # Create the legend.
-    for gene in record.record.geneList:
-        for transcript in sorted(gene.transcriptList, key=attrgetter('name')):
-            if not transcript.name:
-                continue
-            output.addOutput('legends',
-                             ['%s_v%s' % (gene.name, transcript.name),
-                              transcript.transcriptID, transcript.locusTag,
-                              transcript.transcriptProduct,
-                              transcript.linkMethod])
-            if transcript.translate:
-                output.addOutput('legends',
-                                 ['%s_i%s' % (gene.name, transcript.name),
-                                  transcript.proteinID, transcript.locusTag,
-                                  transcript.proteinProduct,
-                                  transcript.linkMethod])
-
     # Note: The GenRecord instance is carrying the sequence in .record.seq.
     #       So is the Mutator instance in .mutator.orig.
 
@@ -1802,6 +1785,25 @@ def check_variant(description, output):
         process_variant(mutator, parsed_description, record, output)
     except _VariantError:
         return
+    finally:
+        # The legend needs to be created after processing the variant (which
+        # enriches the gene model by calling record.checkRecord), but we can
+        # create it regardless of success or failure.
+        for gene in record.record.geneList:
+            for transcript in sorted(gene.transcriptList, key=attrgetter('name')):
+                if not transcript.name:
+                    continue
+                output.addOutput('legends',
+                                 ['%s_v%s' % (gene.name, transcript.name),
+                                  transcript.transcriptID, transcript.locusTag,
+                                  transcript.transcriptProduct,
+                                  transcript.linkMethod])
+                if transcript.translate:
+                    output.addOutput('legends',
+                                     ['%s_i%s' % (gene.name, transcript.name),
+                                      transcript.proteinID, transcript.locusTag,
+                                      transcript.proteinProduct,
+                                      transcript.linkMethod])
 
     output.addOutput('original', unicode(mutator.orig))
     output.addOutput('mutated', unicode(mutator.mutated))

--- a/tests/test_variantchecker.py
+++ b/tests/test_variantchecker.py
@@ -1578,3 +1578,15 @@ def test_start_codon_alt_start_yield_start(output, checker):
     assert output.getOutput('oldProtein')[0].startswith('M')
     assert 'ATG' in output.getOutput('altStart')
     assert output.getOutput('altProtein')[0].startswith('M')
+
+
+@with_references('AB026906.1')
+def test_legend_mrna_by_construction(output, checker):
+    """
+    Transcript created from CDS by construction should be in the legend.
+    """
+    checker('AB026906.1:g.7872G>T')
+    assert output.getOutput('legends') == [
+        ['SDHD_v001', None, None, None, 'construction'],
+        ['SDHD_i001', 'BAA81889.1', None, 'small subunit of cytochrome b of succinate dehydrogenase', 'construction']
+    ]


### PR DESCRIPTION
This fixes a bug where transcripts created from CDS by construction did
not show up in the legend because the legend was created before that
construction.