### PR TITLE
Improve error message when reference is too large

### DIFF
--- a/mutalyzer/Retriever.py
+++ b/mutalyzer/Retriever.py
@@ -382,8 +382,10 @@ class GenBankRetriever(Retriever):
                 return None
             if length > settings.MAX_FILE_SIZE:
                 self._output.addMessage(
-                    __file__, 4, 'ERETR', 'Could not retrieve {}.'.format(
-                        name))
+                    __file__, 4, 'ERETR',
+                    'Could not retrieve {} (exceeds maximum file size of {} '
+                    'megabytes).'.format(
+                        name, settings.MAX_FILE_SIZE // 1048576))
                 return None
             try:
                 net_handle = Entrez.efetch(


### PR DESCRIPTION
This will mainly help when the user tries to use a chromosomal NC
reference in the name checker.