### PR TITLE
Travis updates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,12 @@
 # Validate this file using http://lint.travis-ci.org/
 language: python
+sudo: false
 python: "2.7"
 addons:
+  apt_packages: swig
   postgresql: "9.4"
 services: redis-server
 before_install:
-  - sudo apt-get update -qq
-  - sudo apt-get install -y swig
   - CFLAGS=-O0 pip install -r requirements.txt
   - pip install psycopg2
 install: pip install .

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 # Validate this file using http://lint.travis-ci.org/
 language: python
 sudo: false
+cache: pip
 python: "2.7"
 addons:
   apt_packages: swig


### PR DESCRIPTION
Looks like our tests take slightly longer (~ 1min45) in the new container infrastructure (used when specifying `sudo: false`), but they are started sooner. Also considering this is probably closer to future build environments, I think it's good to switch.