### PR TITLE
Fix installation on CentOS 6

### DIFF
--- a/doc/install.rst
+++ b/doc/install.rst
@@ -18,9 +18,6 @@ which is the recommended setup.
    `Debian`_ 8 *jessie* system. You'll have to figure out the necessary
    adjustments yourself if you're on another system.
 
-   For example, RHEL6/CentOS6 is known to come with a version of libmagic
-   which is incompatible with Mutalyzer.
-
 The following steps will get Mutalyzer running on your system with the
 recommended setup:
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
--e git+https://github.com/LUMC/magic-python.git#egg=Magic_file_extensions
+-e git+https://github.com/mutalyzer/magic-python.git@centos6-fix#egg=Magic_file_extensions
 Flask==0.10.1
 Jinja2==2.8
 MySQL-python==1.2.5


### PR DESCRIPTION
We use a patched magic package to work with the version of magiclib that
is packaged with CentOS 6.7.

https://stackoverflow.com/questions/34541129/mutalyzer-py-test-fails-with-python-magic-error