### PR TITLE
Fix typo in citing description extractor

### DIFF
--- a/mutalyzer/website/templates/about.html
+++ b/mutalyzer/website/templates/about.html
@@ -109,7 +109,7 @@ please mention
 </p>
 
 <p>
-The <a href="{{ url_for('.position_converter') }}">Positon Converter</a> is
+The <a href="{{ url_for('.description_extractor') }}">Description Extractor</a> is
 described separately in <a href="">&quot;Vis JK et al. (2015). An efficient
     algorithm for the extraction of HGVS variant descriptions from
     sequences. Bioinformatics, 2015 Dec 1;31(23):3751-7&quot;</a>


### PR DESCRIPTION
Thanks @jkvis

https://github.com/mutalyzer/mutalyzer/commit/d53bca69e7b17c8111beb82c30d3d0094ef1bd69#commitcomment-17299412