### PR TITLE
Fix reference file loading by url

### DIFF
--- a/mutalyzer/Retriever.py
+++ b/mutalyzer/Retriever.py
@@ -673,7 +673,7 @@ class GenBankRetriever(Retriever):
 
         handle = urllib2.urlopen(url)
         info = handle.info()
-        if info['Content-Type'] == 'text/plain':
+        if info.gettype() == 'text/plain':
             length = int(info['Content-Length'])
             if 512 < length < settings.MAX_FILE_SIZE:
                 raw_data = handle.read()


### PR DESCRIPTION
For some reason there is no `Content-Type` key in the object returned by
`urllib2.urlopen().info()`. However, the `gettype()` method seems to
work.

I have no idea if this code ever worked, and if so, why. Also, the check
for the `text/plain` content type is pretty bogus in my opinion. A
server can say whatever it likes and valid GenBank files may well be
served with different content types.