### PR TITLE
Continue execution in check_variant() after EINVALIDTRANSVAR

### DIFF
--- a/mutalyzer/variantchecker.py
+++ b/mutalyzer/variantchecker.py
@@ -1761,7 +1761,6 @@ def check_variant(description, output):
         else:
             output.addMessage(__file__, 4, 'EINVALIDTRANSVAR',
                 'Invalid name for transcript variant identifier.')
-            return
 
     # Add recordType to output for output formatting.
     output.addOutput('recordType', filetype)


### PR DESCRIPTION
Continue execution in check_variant() after EINVALIDTRANSVAR, this way output (such as legend) is still generated as usual, even if the variant cannot be properly processed.