### PR TITLE
Fix for unexpected batch processor crash

### DIFF
--- a/mutalyzer/Scheduler.py
+++ b/mutalyzer/Scheduler.py
@@ -195,6 +195,9 @@ Mutalyzer batch scheduler""" % download_url)
             if "S0" in flags :
                 message = "Entry could not be formatted correctly, check "\
                         "batch input file help for details"
+            elif "S2" in flags:
+                message = "Unaccepted input line length, check "\
+                        "batch input file help for details"
             elif "S9" in flags :
                 message = "Empty Line"
             else :
@@ -259,7 +262,8 @@ Mutalyzer batch scheduler""" % download_url)
             BatchQueueItem.query \
                 .filter_by(batch_job_id=jobID) \
                 .filter(BatchQueueItem.item.startswith(old),
-                        ~BatchQueueItem.item.startswith(nselector)) \
+                        ~BatchQueueItem.item.startswith(nselector),
+                        ~BatchQueueItem.flags.contains('S2')) \
                 .update({'item': func.replace(BatchQueueItem.item, old, new),
                          'flags': BatchQueueItem.flags + flag},
                             synchronize_session=False)
@@ -803,6 +807,8 @@ Mutalyzer batch scheduler""" % download_url)
                 else:
                     flag = "S9"     # Flag for empty line
                     inputl = " " #Database doesn't like an empty inputfield
+            elif len(inputl) > 190:  # Input line length not accepted
+                flag = "S2"         # Flag for unaccepted input line length
             else:
                 flag = None
             if (i + 1) % columns:

--- a/mutalyzer/Scheduler.py
+++ b/mutalyzer/Scheduler.py
@@ -261,7 +261,7 @@ Mutalyzer batch scheduler""" % download_url)
         try:
             BatchQueueItem.query \
                 .filter_by(batch_job_id=jobID) \
-                .filter(BatchQueueItem.item.startswith(old),
+                .filter(BatchQueueItem.item.startswith(old+':'),
                         ~BatchQueueItem.item.startswith(nselector),
                         ~BatchQueueItem.flags.contains('S2')) \
                 .update({'item': func.replace(BatchQueueItem.item, old, new),

--- a/mutalyzer/website/templates/batch-jobs.html
+++ b/mutalyzer/website/templates/batch-jobs.html
@@ -67,7 +67,7 @@
   </ul>
   <p>
     The maximum file size is {{ max_file_size }} megabytes, and the maximum
-    length per entry (variant description) is 200 characters.
+    length per entry (variant description) is 190 characters.
   </p>
 
   <p>We accept two types of input files, you can download examples below.</p>

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -289,6 +289,93 @@ def test_name_checker_altered():
         _batch_job_plain_text(variants, expected, 'name-checker')
 
 
+def test_name_checker_altered_long_entry():
+    """
+    Name checker job with altered entries but that have one longer than 190 chars.
+    """
+    variants = ['NM_000059:c.670dup',
+                'NM_000059:c.3609_3788AAGTAATATTCCAACAAGTGGTGCCATAGGAAAAAGCAC'
+                'CCTGGTTCCCTTGGACACTCCATCTCCAGCCACATCATTGGAGGCATCAGAAGGGGGACT'
+                'TCCAACCCTCAGCACCTACCCTGAATCAACAAACACACCCAGCATCCACCTCGGAGCACA'
+                'CGCTAGTTCAGAAAGTCCG',
+                'NM_000059:c.670G>T',
+                'NM_000059.3:c.670G>T']
+    expected = [['NM_000059:c.670dup',
+                 '|'.join(['(Retriever): No version number is given, '
+                           'using NM_000059.3. Please use this number to '
+                           'reduce downloading overhead.',
+                           '(Scheduler): All further occurrences of '
+                           'NM_000059 will be substituted by '
+                           'NM_000059.3']),
+                 'NM_000059',
+                 'BRCA2_v001',
+                 'c.670dup',
+                 'n.897dup',
+                 'c.670dup',
+                 'p.(Asp224Glyfs*5)',
+                 'BRCA2_v001:c.670dup',
+                 'BRCA2_v001:p.(Asp224Glyfs*5)',
+                 '',
+                 'NM_000059.3',
+                 'NP_000050.2',
+                 'NM_000059(BRCA2_v001):c.670dup',
+                 'NM_000059(BRCA2_i001):p.(Asp224Glyfs*5)',
+                 'BciVI',
+                 'BspHI,Hpy188III'],
+                ['NM_000059:c.3609_3788AAGTAATATTCCAACAAGTGGTGCCATAGGAAAAAGCAC'
+                'CCTGGTTCCCTTGGACACTCCATCTCCAGCCACATCATTGGAGGCATCAGAAGGGGGACT'
+                'TCCAACCCTCAGCACCTACCCTGAATCAACAAACACACCCAGCATCCACCTCGGAGCACA'
+                'CGCTAGTTCAGAAAGTCCG',
+                 '(Scheduler): Unaccepted input line length, check batch input file help for details'],
+                ['NM_000059.3:c.670G>T',
+                 '(Scheduler): Entry altered before execution',
+                 'NM_000059.3',
+                 'BRCA2_v001',
+                 'c.670G>T',
+                 'n.897G>T',
+                 'c.670G>T',
+                 'p.(Asp224Tyr)',
+                 'BRCA2_v001:c.670G>T',
+                 'BRCA2_v001:p.(Asp224Tyr)',
+                 '',
+                 'NM_000059.3',
+                 'NP_000050.2',
+                 'NM_000059.3(BRCA2_v001):c.670G>T',
+                 'NM_000059.3(BRCA2_i001):p.(Asp224Tyr)',
+                 '',
+                 'BspHI,CviAII,FatI,Hpy188III,NlaIII'],
+                ['NM_000059.3:c.670G>T',
+                 '',
+                 'NM_000059.3',
+                 'BRCA2_v001',
+                 'c.670G>T',
+                 'n.897G>T',
+                 'c.670G>T',
+                 'p.(Asp224Tyr)',
+                 'BRCA2_v001:c.670G>T',
+                 'BRCA2_v001:p.(Asp224Tyr)',
+                 '',
+                 'NM_000059.3',
+                 'NP_000050.2',
+                 'NM_000059.3(BRCA2_v001):c.670G>T',
+                 'NM_000059.3(BRCA2_i001):p.(Asp224Tyr)',
+                 '',
+                 'BspHI,CviAII,FatI,Hpy188III,NlaIII']]
+
+    # Patch GenBankRetriever.fetch to return the contents of NM_000059.3
+    # for NM_000059.
+    def mock_efetch(*args, **kwargs):
+        if kwargs.get('id') != 'NM_000059':
+            return Entrez.efetch(*args, **kwargs)
+        path = os.path.join(os.path.dirname(os.path.realpath(__file__)),
+                            'data',
+                            'NM_000059.3.gb.bz2')
+        return bz2.BZ2File(path)
+
+    with patch.object(Entrez, 'efetch', mock_efetch):
+        _batch_job_plain_text(variants, expected, 'name-checker')
+
+
 @with_references('NM_000059.3')
 def test_name_checker_skipped():
     """


### PR DESCRIPTION
Problem
-----------

It looks like the batch processor crashes in the `__alterBatchEntries` function. Considering an input file with the following contents:
  - NM_024690:c.40638_40638delinsCTGGA
 - NM_024690:c.3609_3788AAGTAATATTCCAACAAGTGGTGCCATAGGAAAAAGCACCCTGGTTCCCTTGGACACTCCATCTCCAGCCACATCATTGGAGGCATCAGAAGGGGGACTTCCACCCTCAGCACCTACCCTGAATCAACAAACACACCCAGCATCCACCTCGGAGCACACGCTAGTTCAGAAAGTCCG

During the processing of the first job (which proceeds without crashing) Mutalyzer fetches the most recent version for *NM_024690*, which is *NM_024690.2*. Next it tries to update any other entries in the `batch_queue_items` database table which utilize only *NM_024690* to the most recent version. This is done in order to speed up the batch process when those jobs are reached. In this case it tries to update the second job. The information stored in the `item` column of the `batch_queue_items` table for the second job has 200 characters, which is to be replaced by a larger one, of 202 characters. Since this is greater than the maximum allowed, the query results in an error:

    (psycopg2.DataError) value too long for type character varying(200)

It seems that an input line is automatically truncated to 200 characters when added to the database, so no error appears there, but during the replace operation the truncation is no longer performed.

Possible solutions
-----------------------

1. Change the `item` column type in `batch_queue_items` table to a variable unlimited length type. This [is supported by PostgreSQL as type *text*](https://www.postgresql.org/docs/current/static/datatype-character.html) but didn't check for other SQL database management systems.
2. Don't process (skip) entries which are longer than 200 chars and do not perform the replacement query on them.