### PR TITLE
Make sure getGeneLocation uses standard strategy to select mapping

### DIFF
--- a/mutalyzer/services/rpc.py
+++ b/mutalyzer/services/rpc.py
@@ -1522,6 +1522,8 @@ class MutalyzerService(ServiceBase):
         # From all the transcripts for this gene, get the lowest start
         # position and highest stop position. For integrity, we group by
         # chromosome and orientation.
+        # Order by chromosome name for disambiguation, as is done in
+        # Convertor._get_mapping()
         mapping = \
             session.query(func.min(TranscriptMapping.start),
                           func.max(TranscriptMapping.stop),
@@ -1533,6 +1535,7 @@ class MutalyzerService(ServiceBase):
                    .join(TranscriptMapping.chromosome) \
                    .group_by(Chromosome.id,
                              TranscriptMapping.orientation) \
+                   .order_by(Chromosome.name.asc()) \
                    .first()
 
         if not mapping:

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -639,6 +639,36 @@ def hg19_transcript_mappings(db, hg19):
         transcript=1,
         cds=(207627764, 207658899),
         select_transcript=True))
+    db.session.add(TranscriptMapping(
+        hg19.chromosomes.filter_by(name='chrY').one(),
+        'refseq',
+        'NM_001145149',
+        'VAMP7',
+        'forward',
+        59213953,
+        59276439,
+        [59213953],
+        [59276439],
+        'ncbi',
+        transcript=1,
+        cds=(59213954, 59276438),
+        select_transcript=False,
+        version=2))
+    db.session.add(TranscriptMapping(
+        hg19.chromosomes.filter_by(name='chrX').one(),
+        'refseq',
+        'NM_001145149',
+        'VAMP7',
+        'forward',
+        155110947,
+        155173433,
+        [155110947],
+        [155173433],
+        'ncbi',
+        transcript=1,
+        cds=(155110948, 155173432),
+        select_transcript=False,
+        version=2))
 
     db.session.commit()
 

--- a/tests/test_services_json.py
+++ b/tests/test_services_json.py
@@ -331,3 +331,20 @@ def test_description_extract_sample_too_long(api):
         api('descriptionExtract',
             'A' * (settings.EXTRACTOR_MAX_INPUT_LENGTH),
             'A' * (settings.EXTRACTOR_MAX_INPUT_LENGTH + 1))
+
+
+@pytest.mark.usefixtures('hg19_transcript_mappings')
+def test_transcript_order(api):
+    """
+    Test whether getGeneLocation and numberConversion have same strategy for
+    selecting a transcript mapping.
+    """
+    result_GL = api('getGeneLocation', gene='VAMP7', build='hg19')
+    result_NC = api('numberConversion', build='hg19',
+                    variant='NM_001145149.2:c.100dup', gene='VAMP7')
+
+    assert 'chromosome_accession' in result_GL
+    assert len(result_NC) == 1
+
+    acc = result_GL['chromosome_accession']
+    assert result_NC[0][:len(acc)] == acc


### PR DESCRIPTION
When multiple mappings available, getGeneLocation now orders by chromosome name before returning the first mapping, as is standard for code based on Convertor._get_mapping().