### PR TITLE
Update broken external link

### DIFF
--- a/extras/soap-tools/sp.py
+++ b/extras/soap-tools/sp.py
@@ -3,7 +3,7 @@
 # Example SOAP client for the Mutalyzer web service in Python using the
 # SOAPpy library.
 #
-# See http://www.mutalyzer.nl/2.0/webservices
+# See https://www.mutalyzer.nl/webservices
 #
 # Usage:
 #   python sp.py


### PR DESCRIPTION
Updated a broken link reference that was moved from:

https://www.mutalyzer.nl/2.0/webservices

to

https://www.mutalyzer.nl/webservices