### PR TITLE
Fix end handling in slice_seq

### DIFF
--- a/mutalyzer/protein.py
+++ b/mutalyzer/protein.py
@@ -306,7 +306,7 @@ def slice_seq(seq, slices, start=None, end=None):
     for s in slices:
         output += seq[s[0] : s[1]]
     start = new_index(start, slices) if start else 0
-    end = new_index(end, slices) if end else -1
+    end = new_index(end, slices) if end else None
     return output[start:end]
 
 


### PR DESCRIPTION
The slice_seq operation has an off by 1 error.
If an end is not specified, it uses `-1` with the intended purpose of including the rest of the seq.
However, this is not the case as this slice operation only includes the penultimate character:
```
>>> seq = 'CCATTGCTAAGCTCTCATG'
>>> seq[0:-1] # will not include the last G
'CCATTGCTAAGCTCTCAT'
>>> seq[0:None] # will include the last G
'CCATTGCTAAGCTCTCATG'
```

Setting `-1` to `None` should fix the issue

